### PR TITLE
Fix docker usage during release process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ currentBranch = "${env.BRANCH_NAME}"
 node('docker') {
     // make directory layout more predictable as go unit tests may fail with different directories
     def jobName = JOB_NAME.replaceAll("%2F",'_').toLowerCase().split("/")[-1]
-    def jobNameShort = jobName[0..10]
+    def jobNameShort = jobName.length() >= 10 ? jobName[0..10] : jobName
     ws( "workspace/${repositoryName}_${jobNameShort}_${BUILD_NUMBER}") {
 
         timestamps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,6 @@ node('docker') {
     // make directory layout more predictable as go unit tests may fail with different directories
     def jobName = JOB_NAME.replaceAll("%2F",'_').toLowerCase().split("/")[-1]
     def jobNameShort = jobName[0..10]
-    echo "##### workspace/${repositoryName}_${jobNameShort}_${BUILD_NUMBER} #####"
     ws( "workspace/${repositoryName}_${jobNameShort}_${BUILD_NUMBER}") {
 
         timestamps {


### PR DESCRIPTION
When using the same variable for a docker interaction this error message may occur.

java.lang.StackOverflowError: Excessively nested closures/functions at com.cloudogu.ces.cesbuildlib.Docker$Image.workAroundEntrypointIssues(Docker.groovy:347) - look for unbounded recursion - call depth: 1025

As the error message does not occur when a different name is used my guess is that a variable re-usage within the library leads to the stackoverflow.

See also https://stackoverflow.com/questions/50705680/jenkins-pipeline-throws-stackoverflowerror-excessively-nested-closures-functio

This PR also resolves a directory naming problem during CI in which the directory name is mangled and certain reflecting unit tests no longer work.